### PR TITLE
Downgrade to Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.target>1.8</maven.compiler.target>
-		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
+		<maven.compiler.source>1.7</maven.compiler.source>
 	</properties>
 
 	<build>

--- a/src/main/java/io/usethesource/capsule/ImmutableMap.java
+++ b/src/main/java/io/usethesource/capsule/ImmutableMap.java
@@ -16,41 +16,41 @@ import java.util.Map;
 public interface ImmutableMap<K, V> extends Map<K, V> {
 
   @Override
-  public V get(final Object o);
+  V get(final Object o);
 
-  public V getEquivalent(final Object o, final Comparator<Object> cmp);
-
-  @Override
-  public boolean containsKey(final Object o);
-
-  public boolean containsKeyEquivalent(final Object o, final Comparator<Object> cmp);
+  V getEquivalent(final Object o, final Comparator<Object> cmp);
 
   @Override
-  public boolean containsValue(final Object o);
+  boolean containsKey(final Object o);
 
-  public boolean containsValueEquivalent(final Object o, final Comparator<Object> cmp);
+  boolean containsKeyEquivalent(final Object o, final Comparator<Object> cmp);
 
-  public ImmutableMap<K, V> __put(final K key, final V val);
+  @Override
+  boolean containsValue(final Object o);
 
-  public ImmutableMap<K, V> __putEquivalent(final K key, final V val, final Comparator<Object> cmp);
+  boolean containsValueEquivalent(final Object o, final Comparator<Object> cmp);
 
-  public ImmutableMap<K, V> __putAll(final Map<? extends K, ? extends V> map);
+  ImmutableMap<K, V> __put(final K key, final V val);
 
-  public ImmutableMap<K, V> __putAllEquivalent(final Map<? extends K, ? extends V> map,
-      final Comparator<Object> cmp);
+  ImmutableMap<K, V> __putEquivalent(final K key, final V val, final Comparator<Object> cmp);
 
-  public ImmutableMap<K, V> __remove(final K key);
+  ImmutableMap<K, V> __putAll(final Map<? extends K, ? extends V> map);
 
-  public ImmutableMap<K, V> __removeEquivalent(final K key, final Comparator<Object> cmp);
+  ImmutableMap<K, V> __putAllEquivalent(final Map<? extends K, ? extends V> map,
+                                        final Comparator<Object> cmp);
 
-  public Iterator<K> keyIterator();
+  ImmutableMap<K, V> __remove(final K key);
 
-  public Iterator<V> valueIterator();
+  ImmutableMap<K, V> __removeEquivalent(final K key, final Comparator<Object> cmp);
 
-  public Iterator<Map.Entry<K, V>> entryIterator();
+  Iterator<K> keyIterator();
 
-  public boolean isTransientSupported();
+  Iterator<V> valueIterator();
 
-  public TransientMap<K, V> asTransient();
+  Iterator<Map.Entry<K, V>> entryIterator();
+
+  boolean isTransientSupported();
+
+  TransientMap<K, V> asTransient();
 
 }

--- a/src/main/java/io/usethesource/capsule/ImmutableSet.java
+++ b/src/main/java/io/usethesource/capsule/ImmutableSet.java
@@ -17,46 +17,46 @@ import java.util.Set;
 public interface ImmutableSet<K> extends Set<K> {
 
   @Override
-  public boolean containsAll(final Collection<?> c);
+  boolean containsAll(final Collection<?> c);
 
-  public boolean containsAllEquivalent(final Collection<?> c, final Comparator<Object> cmp);
+  boolean containsAllEquivalent(final Collection<?> c, final Comparator<Object> cmp);
 
-  public K get(final Object o);
+  K get(final Object o);
 
-  public K getEquivalent(final Object o, final Comparator<Object> cmp);
+  K getEquivalent(final Object o, final Comparator<Object> cmp);
 
   @Override
-  public boolean contains(final Object o);
+  boolean contains(final Object o);
 
-  public boolean containsEquivalent(final Object o, final Comparator<Object> cmp);
+  boolean containsEquivalent(final Object o, final Comparator<Object> cmp);
 
-  public ImmutableSet<K> __insert(final K key);
+  ImmutableSet<K> __insert(final K key);
 
-  public ImmutableSet<K> __insertEquivalent(final K key, final Comparator<Object> cmp);
+  ImmutableSet<K> __insertEquivalent(final K key, final Comparator<Object> cmp);
 
-  public ImmutableSet<K> __insertAll(final Set<? extends K> set);
+  ImmutableSet<K> __insertAll(final Set<? extends K> set);
 
-  public ImmutableSet<K> __insertAllEquivalent(final Set<? extends K> set,
-      final Comparator<Object> cmp);
+  ImmutableSet<K> __insertAllEquivalent(final Set<? extends K> set,
+                                        final Comparator<Object> cmp);
 
-  public ImmutableSet<K> __remove(final K key);
+  ImmutableSet<K> __remove(final K key);
 
-  public ImmutableSet<K> __removeEquivalent(final K key, final Comparator<Object> cmp);
+  ImmutableSet<K> __removeEquivalent(final K key, final Comparator<Object> cmp);
 
-  public ImmutableSet<K> __removeAll(final Set<? extends K> set);
+  ImmutableSet<K> __removeAll(final Set<? extends K> set);
 
-  public ImmutableSet<K> __removeAllEquivalent(final Set<? extends K> set,
-      final Comparator<Object> cmp);
+  ImmutableSet<K> __removeAllEquivalent(final Set<? extends K> set,
+                                        final Comparator<Object> cmp);
 
-  public ImmutableSet<K> __retainAll(final Set<? extends K> set);
+  ImmutableSet<K> __retainAll(final Set<? extends K> set);
 
-  public ImmutableSet<K> __retainAllEquivalent(final TransientSet<? extends K> transientSet,
-      final Comparator<Object> cmp);
+  ImmutableSet<K> __retainAllEquivalent(final TransientSet<? extends K> transientSet,
+                                        final Comparator<Object> cmp);
 
-  public Iterator<K> keyIterator();
+  Iterator<K> keyIterator();
 
-  public boolean isTransientSupported();
+  boolean isTransientSupported();
 
-  public TransientSet<K> asTransient();
+  TransientSet<K> asTransient();
 
 }

--- a/src/main/java/io/usethesource/capsule/TransientMap.java
+++ b/src/main/java/io/usethesource/capsule/TransientMap.java
@@ -16,39 +16,39 @@ import java.util.Map;
 public interface TransientMap<K, V> extends Map<K, V> {
 
   @Override
-  public V get(final Object o);
+  V get(final Object o);
 
-  public V getEquivalent(final Object o, final Comparator<Object> cmp);
-
-  @Override
-  public boolean containsKey(final Object o);
-
-  public boolean containsKeyEquivalent(final Object o, final Comparator<Object> cmp);
+  V getEquivalent(final Object o, final Comparator<Object> cmp);
 
   @Override
-  public boolean containsValue(final Object o);
+  boolean containsKey(final Object o);
 
-  public boolean containsValueEquivalent(final Object o, final Comparator<Object> cmp);
+  boolean containsKeyEquivalent(final Object o, final Comparator<Object> cmp);
 
-  public V __put(final K key, final V val);
+  @Override
+  boolean containsValue(final Object o);
 
-  public V __putEquivalent(final K key, final V val, final Comparator<Object> cmp);
+  boolean containsValueEquivalent(final Object o, final Comparator<Object> cmp);
 
-  public boolean __putAll(final Map<? extends K, ? extends V> map);
+  V __put(final K key, final V val);
 
-  public boolean __putAllEquivalent(final Map<? extends K, ? extends V> map,
-      final Comparator<Object> cmp);
+  V __putEquivalent(final K key, final V val, final Comparator<Object> cmp);
 
-  public V __remove(final K key);
+  boolean __putAll(final Map<? extends K, ? extends V> map);
 
-  public V __removeEquivalent(final K key, final Comparator<Object> cmp);
+  boolean __putAllEquivalent(final Map<? extends K, ? extends V> map,
+                             final Comparator<Object> cmp);
 
-  public Iterator<K> keyIterator();
+  V __remove(final K key);
 
-  public Iterator<V> valueIterator();
+  V __removeEquivalent(final K key, final Comparator<Object> cmp);
 
-  public Iterator<Map.Entry<K, V>> entryIterator();
+  Iterator<K> keyIterator();
 
-  public ImmutableMap<K, V> freeze();
+  Iterator<V> valueIterator();
+
+  Iterator<Map.Entry<K, V>> entryIterator();
+
+  ImmutableMap<K, V> freeze();
 
 }

--- a/src/main/java/io/usethesource/capsule/TransientSet.java
+++ b/src/main/java/io/usethesource/capsule/TransientSet.java
@@ -17,42 +17,42 @@ import java.util.Set;
 public interface TransientSet<K> extends Set<K> {
 
   @Override
-  public boolean containsAll(final Collection<?> c);
+  boolean containsAll(final Collection<?> c);
 
-  public boolean containsAllEquivalent(final Collection<?> c, final Comparator<Object> cmp);
+  boolean containsAllEquivalent(final Collection<?> c, final Comparator<Object> cmp);
 
-  public K get(final Object o);
+  K get(final Object o);
 
-  public K getEquivalent(final Object o, final Comparator<Object> cmp);
+  K getEquivalent(final Object o, final Comparator<Object> cmp);
 
   @Override
-  public boolean contains(final Object o);
+  boolean contains(final Object o);
 
-  public boolean containsEquivalent(final Object o, final Comparator<Object> cmp);
+  boolean containsEquivalent(final Object o, final Comparator<Object> cmp);
 
-  public boolean __insert(final K key);
+  boolean __insert(final K key);
 
-  public boolean __insertEquivalent(final K key, final Comparator<Object> cmp);
+  boolean __insertEquivalent(final K key, final Comparator<Object> cmp);
 
-  public boolean __insertAll(final Set<? extends K> set);
+  boolean __insertAll(final Set<? extends K> set);
 
-  public boolean __insertAllEquivalent(final Set<? extends K> set, final Comparator<Object> cmp);
+  boolean __insertAllEquivalent(final Set<? extends K> set, final Comparator<Object> cmp);
 
-  public boolean __remove(final K key);
+  boolean __remove(final K key);
 
-  public boolean __removeEquivalent(final K key, final Comparator<Object> cmp);
+  boolean __removeEquivalent(final K key, final Comparator<Object> cmp);
 
-  public boolean __removeAll(final Set<? extends K> set);
+  boolean __removeAll(final Set<? extends K> set);
 
-  public boolean __removeAllEquivalent(final Set<? extends K> set, final Comparator<Object> cmp);
+  boolean __removeAllEquivalent(final Set<? extends K> set, final Comparator<Object> cmp);
 
-  public boolean __retainAll(final Set<? extends K> set);
+  boolean __retainAll(final Set<? extends K> set);
 
-  public boolean __retainAllEquivalent(final TransientSet<? extends K> transientSet,
-      final Comparator<Object> cmp);
+  boolean __retainAllEquivalent(final TransientSet<? extends K> transientSet,
+                                final Comparator<Object> cmp);
 
-  public Iterator<K> keyIterator();
+  Iterator<K> keyIterator();
 
-  public ImmutableSet<K> freeze();
+  ImmutableSet<K> freeze();
 
 }


### PR DESCRIPTION
The library doesn't use any of the Java 8 classes or utilities. A Java 7 version downgrade makes it usable off the jar directly on Android, which is a massive Java consumer market.

I also removed the public identifier from the interfaces, as interfaces don't allow private or package encapsulation anyway.