### PR TITLE
Reduce allocations empty of EnumSet inside MultimapResultImpl

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,9 @@ node {
           }
 
           stage('Deploy') {
+            if (env.BRANCH_NAME == "master" || env.BRANCH_NAME == "jenkins-deploy") {
               sh "mvn deploy -DskipTests"
+            }
           }
       }
 

--- a/capsule-core/src/main/java/io/usethesource/capsule/core/AbstractPersistentTrieSetMultimap.java
+++ b/capsule-core/src/main/java/io/usethesource/capsule/core/AbstractPersistentTrieSetMultimap.java
@@ -107,7 +107,7 @@ public abstract class AbstractPersistentTrieSetMultimap<K, V, C extends Iterable
         int propertyKeySetHashCode = cachedKeySetHashCode;
         int propertyKeySetSize = cachedKeySetSize;
 
-        if (details.getModificationDetails().contains(INSERTED_KEY)) {
+        if (details.containsModification(INSERTED_KEY)) {
           propertyKeySetHashCode += keyHash;
           propertyKeySetSize += 1;
         }
@@ -160,7 +160,7 @@ public abstract class AbstractPersistentTrieSetMultimap<K, V, C extends Iterable
       }
 
       case INSERTED_PAYLOAD: {
-        assert details.getModificationDetails().contains(INSERTED_KEY);
+        assert details.containsModification(INSERTED_KEY);
 
         // int hashCodeDeltaNew = tupleHash(keyHash, values);
         // int propertyHashCode = cachedHashCode + hashCodeDeltaNew;
@@ -199,7 +199,7 @@ public abstract class AbstractPersistentTrieSetMultimap<K, V, C extends Iterable
         int propertyKeySetHashCode = cachedKeySetHashCode;
         int propertyKeySetSize = cachedKeySetSize;
 
-        if (details.getModificationDetails().contains(REMOVED_KEY)) {
+        if (details.containsModification(REMOVED_KEY)) {
           propertyKeySetHashCode -= keyHash;
           propertyKeySetSize -= 1;
         }
@@ -227,7 +227,7 @@ public abstract class AbstractPersistentTrieSetMultimap<K, V, C extends Iterable
       }
 
       case REMOVED_PAYLOAD: {
-        assert details.getModificationDetails().contains(REMOVED_KEY);
+        assert details.containsModification(REMOVED_KEY);
 
         // int hashCodeDeltaOld = tupleHash(keyHash, details.getEvictedPayload());
         // int propertyHashCode = cachedHashCode - hashCodeDeltaOld;

--- a/capsule-core/src/main/java/io/usethesource/capsule/core/AbstractTransientTrieSetMultimap.java
+++ b/capsule-core/src/main/java/io/usethesource/capsule/core/AbstractTransientTrieSetMultimap.java
@@ -114,7 +114,7 @@ public abstract class AbstractTransientTrieSetMultimap<K, V, C extends Iterable<
         this.cachedKeySetHashCode = cachedKeySetHashCode;
         this.cachedKeySetSize = cachedKeySetSize;
 
-        if (details.getModificationDetails().contains(INSERTED_KEY)) {
+        if (details.containsModification(INSERTED_KEY)) {
           this.cachedKeySetHashCode += keyHash;
           this.cachedKeySetSize += 1;
         }
@@ -175,7 +175,7 @@ public abstract class AbstractTransientTrieSetMultimap<K, V, C extends Iterable<
       }
 
       case INSERTED_PAYLOAD: {
-        assert details.getModificationDetails().contains(INSERTED_KEY);
+        assert details.containsModification(INSERTED_KEY);
 
         // int hashCodeDeltaNew = tupleHash(keyHash, values);
         // this.cachedHashCode = cachedHashCode + hashCodeDeltaNew;
@@ -220,7 +220,7 @@ public abstract class AbstractTransientTrieSetMultimap<K, V, C extends Iterable<
         this.cachedKeySetHashCode = cachedKeySetHashCode;
         this.cachedKeySetSize = cachedKeySetSize;
 
-        if (details.getModificationDetails().contains(REMOVED_KEY)) {
+        if (details.containsModification(REMOVED_KEY)) {
           this.cachedKeySetHashCode -= keyHash;
           this.cachedKeySetSize -= 1;
         }
@@ -254,7 +254,7 @@ public abstract class AbstractTransientTrieSetMultimap<K, V, C extends Iterable<
       }
 
       case REMOVED_PAYLOAD: {
-        assert details.getModificationDetails().contains(REMOVED_KEY);
+        assert details.containsModification(REMOVED_KEY);
 
         // int hashCodeDeltaOld = tupleHash(keyHash, details.getEvictedPayload());
         // this.cachedHashCode = cachedHashCode - hashCodeDeltaOld;

--- a/capsule-core/src/main/java/io/usethesource/capsule/core/PersistentTrieSetMultimap.java
+++ b/capsule-core/src/main/java/io/usethesource/capsule/core/PersistentTrieSetMultimap.java
@@ -827,7 +827,7 @@ public class PersistentTrieSetMultimap<K, V> extends
             final io.usethesource.capsule.Set.Immutable<V> valColl =
                 io.usethesource.capsule.Set.Immutable.of(currentVal, value);
 
-            details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_VALUE), 1);
+            details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_VALUE), 1);
             return copyAndMigrateFromSingletonToCollection(mutator, bitpos, currentKey, valColl);
           }
         } else {
@@ -838,7 +838,7 @@ public class PersistentTrieSetMultimap<K, V> extends
               currentVal, transformHashCode(currentKey.hashCode()), key, value, keyHash,
               shift + BIT_PARTITION_SIZE, cmp);
 
-          details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_KEY, INSERTED_VALUE), 1);
+          details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE), 1);
           return copyAndMigrateFromSingletonToNode(mutator, bitpos, subNodeNew);
         }
       }
@@ -858,7 +858,7 @@ public class PersistentTrieSetMultimap<K, V> extends
             final io.usethesource.capsule.Set.Immutable<V> newCollVal =
                 currentCollVal.__insert(value);
 
-            details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_VALUE), 1);
+            details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_VALUE), 1);
             return copyAndSetCollectionValue(mutator, bitpos, newCollVal);
           }
         } else {
@@ -869,7 +869,7 @@ public class PersistentTrieSetMultimap<K, V> extends
               currentCollKey, currentValues, transformHashCode(currentCollKey.hashCode()), key,
               value, keyHash, shift + BIT_PARTITION_SIZE, cmp);
 
-          details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_KEY, INSERTED_VALUE), 1);
+          details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE), 1);
           return copyAndMigrateFromCollectionToNode(mutator, bitpos, subNodeNew);
         }
       }
@@ -889,7 +889,7 @@ public class PersistentTrieSetMultimap<K, V> extends
       }
 
       // default
-      details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_KEY, INSERTED_VALUE), 1);
+      details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE), 1);
       return copyAndInsertSingleton(mutator, bitpos, key, value);
     }
 
@@ -921,7 +921,7 @@ public class PersistentTrieSetMultimap<K, V> extends
           final io.usethesource.capsule.Set.Immutable<V> mergedValues = values.__insert(currentVal);
           final int sizeDelta = 2 * values.size() - mergedValues.size();
 
-          details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_VALUE_COLLECTION), sizeDelta);
+          details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_VALUE_COLLECTION), sizeDelta);
           return copyAndMigrateFromSingletonToCollection(mutator, bitpos, currentKey, mergedValues);
         } else {
           // prefix-collision (case: singleton x collection)
@@ -932,7 +932,7 @@ public class PersistentTrieSetMultimap<K, V> extends
               shift + BIT_PARTITION_SIZE, cmp);
           final int sizeDelta = values.size();
 
-          details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_KEY, INSERTED_VALUE_COLLECTION),
+          details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE_COLLECTION),
               sizeDelta);
           return copyAndMigrateFromSingletonToNode(mutator, bitpos, subNodeNew);
         }
@@ -954,7 +954,7 @@ public class PersistentTrieSetMultimap<K, V> extends
           if (sizeDelta == 0) {
             return this;
           } else {
-            details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_VALUE_COLLECTION), sizeDelta);
+            details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_VALUE_COLLECTION), sizeDelta);
             return copyAndSetCollectionValue(mutator, bitpos, mergedValues);
           }
         } else {
@@ -966,7 +966,7 @@ public class PersistentTrieSetMultimap<K, V> extends
               values, keyHash, shift + BIT_PARTITION_SIZE, cmp);
           final int sizeDelta = values.size();
 
-          details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_KEY, INSERTED_VALUE_COLLECTION),
+          details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE_COLLECTION),
               sizeDelta);
           return copyAndMigrateFromCollectionToNode(mutator, bitpos, subNodeNew);
         }
@@ -987,7 +987,7 @@ public class PersistentTrieSetMultimap<K, V> extends
       }
 
       // default
-      details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_KEY, INSERTED_VALUE_COLLECTION),
+      details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE_COLLECTION),
           values.size());
       return copyAndInsertCollection(mutator, bitpos, key, values);
     }
@@ -1030,7 +1030,7 @@ public class PersistentTrieSetMultimap<K, V> extends
           final V currentVal = getSingletonValue(dataIndex);
 
           // update singleton value
-          details.modified(REPLACED_PAYLOAD, EnumSet.of(REPLACED_VALUE),
+          details.modified(REPLACED_PAYLOAD, MultimapResult.Modification.flag(REPLACED_VALUE),
               io.usethesource.capsule.Set.Immutable.of(currentVal));
           return copyAndSetSingletonValue(mutator, bitpos, value);
         } else {
@@ -1041,7 +1041,7 @@ public class PersistentTrieSetMultimap<K, V> extends
               currentVal, transformHashCode(currentKey.hashCode()), key, value, keyHash,
               shift + BIT_PARTITION_SIZE, cmp);
 
-          details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_KEY, INSERTED_VALUE));
+          details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE));
           return copyAndMigrateFromSingletonToNode(mutator, bitpos, subNodeNew);
         }
       }
@@ -1055,7 +1055,7 @@ public class PersistentTrieSetMultimap<K, V> extends
               getCollectionValue(collIndex);
 
           // migrate from collection to singleton
-          details.modified(REPLACED_PAYLOAD, EnumSet.of(REPLACED_VALUE_COLLECTION), currentCollVal);
+          details.modified(REPLACED_PAYLOAD, MultimapResult.Modification.flag(REPLACED_VALUE_COLLECTION), currentCollVal);
           return copyAndMigrateFromCollectionToSingleton(mutator, bitpos, currentCollKey, value);
         } else {
           // prefix-collision (case: collection x singleton)
@@ -1065,7 +1065,7 @@ public class PersistentTrieSetMultimap<K, V> extends
               currentCollKey, currentValues, transformHashCode(currentCollKey.hashCode()), key,
               value, keyHash, shift + BIT_PARTITION_SIZE, cmp);
 
-          details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_KEY, INSERTED_VALUE));
+          details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE));
           return copyAndMigrateFromCollectionToNode(mutator, bitpos, subNodeNew);
         }
       }
@@ -1084,7 +1084,7 @@ public class PersistentTrieSetMultimap<K, V> extends
       }
 
       // default
-      details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_KEY, INSERTED_VALUE));
+      details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE));
       return copyAndInsertSingleton(mutator, bitpos, key, value);
     }
 
@@ -1112,7 +1112,7 @@ public class PersistentTrieSetMultimap<K, V> extends
           final V currentVal = getSingletonValue(dataIndex);
 
           // replace singleton value with collection
-          details.modified(REPLACED_PAYLOAD, EnumSet.of(REPLACED_VALUE),
+          details.modified(REPLACED_PAYLOAD, MultimapResult.Modification.flag(REPLACED_VALUE),
               io.usethesource.capsule.Set.Immutable.of(currentVal));
           return copyAndMigrateFromSingletonToCollection(mutator, bitpos, key, values);
         } else {
@@ -1123,7 +1123,7 @@ public class PersistentTrieSetMultimap<K, V> extends
               values, keyHash, currentKey, currentVal,
               transformHashCode(currentKey.hashCode()), shift + BIT_PARTITION_SIZE, cmp);
 
-          details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_KEY, INSERTED_VALUE_COLLECTION));
+          details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE_COLLECTION));
           return copyAndMigrateFromSingletonToNode(mutator, bitpos, subNodeNew);
         }
       }
@@ -1137,7 +1137,7 @@ public class PersistentTrieSetMultimap<K, V> extends
               getCollectionValue(collIndex);
 
           // update collection
-          details.modified(REPLACED_PAYLOAD, EnumSet.of(REPLACED_VALUE_COLLECTION), currentCollVal);
+          details.modified(REPLACED_PAYLOAD, MultimapResult.Modification.flag(REPLACED_VALUE_COLLECTION), currentCollVal);
           return copyAndSetCollectionValue(mutator, bitpos, values);
         } else {
           // prefix-collision (case: collection x collection)
@@ -1147,7 +1147,7 @@ public class PersistentTrieSetMultimap<K, V> extends
               currentCollKey, currentValues, transformHashCode(currentCollKey.hashCode()), key,
               values, keyHash, shift + BIT_PARTITION_SIZE, cmp);
 
-          details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_KEY, INSERTED_VALUE_COLLECTION));
+          details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE_COLLECTION));
           return copyAndMigrateFromCollectionToNode(mutator, bitpos, subNodeNew);
         }
       }
@@ -1167,7 +1167,7 @@ public class PersistentTrieSetMultimap<K, V> extends
       }
 
       // default
-      details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_KEY, INSERTED_VALUE_COLLECTION));
+      details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE_COLLECTION));
       return copyAndInsertCollection(mutator, bitpos, key, values);
     }
 
@@ -1197,7 +1197,7 @@ public class PersistentTrieSetMultimap<K, V> extends
           if (cmp.equals(currentVal, value)) {
 
             // remove mapping
-            details.modified(REMOVED_PAYLOAD, EnumSet.of(REMOVED_KEY, REMOVED_VALUE),
+            details.modified(REMOVED_PAYLOAD, MultimapResult.Modification.flag(REMOVED_KEY, REMOVED_VALUE),
                 io.usethesource.capsule.Set.Immutable.of(currentVal));
             return copyAndRemoveSingleton(mutator, bitpos).canonicalize(mutator, keyHash, shift);
 
@@ -1220,7 +1220,7 @@ public class PersistentTrieSetMultimap<K, V> extends
           if (currentValColl.contains(value)) {
 
             // remove mapping
-            details.modified(REMOVED_PAYLOAD, EnumSet.of(REMOVED_VALUE),
+            details.modified(REMOVED_PAYLOAD, MultimapResult.Modification.flag(REMOVED_VALUE),
                 io.usethesource.capsule.Set.Immutable.of(value));
 
             final io.usethesource.capsule.Set.Immutable<V> newValColl =
@@ -1314,7 +1314,7 @@ public class PersistentTrieSetMultimap<K, V> extends
           // return this;
           // }
 
-          details.modified(REMOVED_PAYLOAD, EnumSet.of(REMOVED_KEY, REMOVED_VALUE),
+          details.modified(REMOVED_PAYLOAD, MultimapResult.Modification.flag(REMOVED_KEY, REMOVED_VALUE),
               io.usethesource.capsule.Set.Immutable.of(currentVal));
           return copyAndRemoveSingleton(mutator, bitpos).canonicalize(mutator, keyHash, shift);
         } else {
@@ -1348,7 +1348,7 @@ public class PersistentTrieSetMultimap<K, V> extends
           // return this;
           // }
 
-          details.modified(REMOVED_PAYLOAD, EnumSet.of(REMOVED_KEY, REMOVED_VALUE_COLLECTION),
+          details.modified(REMOVED_PAYLOAD, MultimapResult.Modification.flag(REMOVED_KEY, REMOVED_VALUE_COLLECTION),
               currentValColl);
           return copyAndRemoveCollection(mutator, bitpos).canonicalize(mutator, keyHash, shift);
         } else {
@@ -2510,7 +2510,7 @@ public class PersistentTrieSetMultimap<K, V> extends
                   && entry.getValue().containsEquivalent(value, cmp))
               .findAny().isPresent();
 
-          details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_VALUE), 1);
+          details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_VALUE), 1);
           return new HashCollisionNode<K, V>(hash, updatedCollisionContent);
         }
       } else {
@@ -2534,7 +2534,7 @@ public class PersistentTrieSetMultimap<K, V> extends
             .findAny()
             .isPresent();
 
-        details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_KEY, INSERTED_VALUE), 1);
+        details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE), 1);
         return new HashCollisionNode<K, V>(hash, updatedCollisionContent);
       }
     }
@@ -2569,9 +2569,9 @@ public class PersistentTrieSetMultimap<K, V> extends
             collisionContent.stream().map(substitutionMapper).collect(Collectors.toList());
 
         if (values.size() == 1) {
-          details.modified(REPLACED_PAYLOAD, EnumSet.of(REPLACED_VALUE), values);
+          details.modified(REPLACED_PAYLOAD, MultimapResult.Modification.flag(REPLACED_VALUE), values);
         } else {
-          details.modified(REPLACED_PAYLOAD, EnumSet.of(REPLACED_VALUE_COLLECTION), values);
+          details.modified(REPLACED_PAYLOAD, MultimapResult.Modification.flag(REPLACED_VALUE_COLLECTION), values);
         }
 
         return new HashCollisionNode<K, V>(hash, updatedCollisionContent);
@@ -2587,7 +2587,7 @@ public class PersistentTrieSetMultimap<K, V> extends
         List<Map.Entry<K, io.usethesource.capsule.Set.Immutable<V>>> updatedCollisionContent =
             builder.build().collect(Collectors.toList());
 
-        details.modified(INSERTED_PAYLOAD, EnumSet.of(INSERTED_KEY, INSERTED_VALUE));
+        details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE));
         return new HashCollisionNode<K, V>(hash, updatedCollisionContent);
       }
     }
@@ -2616,7 +2616,7 @@ public class PersistentTrieSetMultimap<K, V> extends
                 .filter(kImmutableSetEntry -> kImmutableSetEntry != optionalTuple.get())
                 .collect(Collectors.toList());
 
-            details.modified(REMOVED_PAYLOAD, EnumSet.of(REMOVED_KEY, REMOVED_VALUE));
+            details.modified(REMOVED_PAYLOAD, MultimapResult.Modification.flag(REMOVED_KEY, REMOVED_VALUE));
             return new HashCollisionNode<K, V>(hash, updatedCollisionContent);
           } else {
             Function<Map.Entry<K, io.usethesource.capsule.Set.Immutable<V>>, Map.Entry<K, io.usethesource.capsule.Set.Immutable<V>>> substitutionMapper =
@@ -2633,7 +2633,7 @@ public class PersistentTrieSetMultimap<K, V> extends
             updatedCollisionContent =
                 collisionContent.stream().map(substitutionMapper).collect(Collectors.toList());
 
-            details.modified(REMOVED_PAYLOAD, EnumSet.of(REMOVED_VALUE));
+            details.modified(REMOVED_PAYLOAD, MultimapResult.Modification.flag(REMOVED_VALUE));
             return new HashCollisionNode<K, V>(hash, updatedCollisionContent);
           }
         }
@@ -2664,11 +2664,11 @@ public class PersistentTrieSetMultimap<K, V> extends
             .collect(Collectors.toList());
 
         if (values.size() == 1) {
-          details.modified(REMOVED_PAYLOAD, EnumSet.of(REMOVED_KEY, REMOVED_VALUE), values);
+          details.modified(REMOVED_PAYLOAD, MultimapResult.Modification.flag(REMOVED_KEY, REMOVED_VALUE), values);
           return new HashCollisionNode<K, V>(hash, updatedCollisionContent);
         } else {
           details
-              .modified(REMOVED_PAYLOAD, EnumSet.of(REMOVED_KEY, REMOVED_VALUE_COLLECTION), values);
+              .modified(REMOVED_PAYLOAD, MultimapResult.Modification.flag(REMOVED_KEY, REMOVED_VALUE_COLLECTION), values);
           return new HashCollisionNode<K, V>(hash, updatedCollisionContent);
         }
       }

--- a/capsule-core/src/main/java/io/usethesource/capsule/core/trie/MultimapResult.java
+++ b/capsule-core/src/main/java/io/usethesource/capsule/core/trie/MultimapResult.java
@@ -9,6 +9,7 @@ package io.usethesource.capsule.core.trie;
 
 import java.util.EnumSet;
 import java.util.Optional;
+import java.util.Set;
 
 public interface MultimapResult<K, V, C> {
 
@@ -18,14 +19,14 @@ public interface MultimapResult<K, V, C> {
 
   Modification getModificationEffect();
 
-  EnumSet<Modification> getModificationDetails();
+  Set<Modification> getModificationDetails();
 
-  void modified(Modification modificationEffect, EnumSet<Modification> modificationDetails);
+  void modified(Modification modificationEffect, Set<Modification> modificationDetails);
 
-  void modified(Modification modificationEffect, EnumSet<Modification> modificationDetails,
+  void modified(Modification modificationEffect, Set<Modification> modificationDetails,
       int sizeDelta);
 
-  void modified(Modification modificationEffect, EnumSet<Modification> modificationDetails,
+  void modified(Modification modificationEffect, Set<Modification> modificationDetails,
       C evictedPayload);
 
   Optional<C> getEvictedPayload();

--- a/capsule-core/src/main/java/io/usethesource/capsule/core/trie/MultimapResult.java
+++ b/capsule-core/src/main/java/io/usethesource/capsule/core/trie/MultimapResult.java
@@ -9,7 +9,6 @@ package io.usethesource.capsule.core.trie;
 
 import java.util.EnumSet;
 import java.util.Optional;
-import java.util.Set;
 
 public interface MultimapResult<K, V, C> {
 
@@ -19,14 +18,14 @@ public interface MultimapResult<K, V, C> {
 
   Modification getModificationEffect();
 
-  Set<Modification> getModificationDetails();
+  boolean containsModification(Modification m);
 
-  void modified(Modification modificationEffect, Set<Modification> modificationDetails);
+  void modified(Modification modificationEffect, EnumSet<Modification> modificationDetails);
 
-  void modified(Modification modificationEffect, Set<Modification> modificationDetails,
+  void modified(Modification modificationEffect, EnumSet<Modification> modificationDetails,
       int sizeDelta);
 
-  void modified(Modification modificationEffect, Set<Modification> modificationDetails,
+  void modified(Modification modificationEffect, EnumSet<Modification> modificationDetails,
       C evictedPayload);
 
   Optional<C> getEvictedPayload();

--- a/capsule-core/src/main/java/io/usethesource/capsule/core/trie/MultimapResult.java
+++ b/capsule-core/src/main/java/io/usethesource/capsule/core/trie/MultimapResult.java
@@ -7,7 +7,6 @@
  */
 package io.usethesource.capsule.core.trie;
 
-import java.util.EnumSet;
 import java.util.Optional;
 
 public interface MultimapResult<K, V, C> {
@@ -20,13 +19,11 @@ public interface MultimapResult<K, V, C> {
 
   boolean containsModification(Modification m);
 
-  void modified(Modification modificationEffect, EnumSet<Modification> modificationDetails);
+  void modified(Modification modificationEffect, int modificationDetails);
 
-  void modified(Modification modificationEffect, EnumSet<Modification> modificationDetails,
-      int sizeDelta);
+  void modified(Modification modificationEffect, int modificationDetails, int sizeDelta);
 
-  void modified(Modification modificationEffect, EnumSet<Modification> modificationDetails,
-      C evictedPayload);
+  void modified(Modification modificationEffect, int modificationDetails, C evictedPayload);
 
   Optional<C> getEvictedPayload();
 
@@ -51,6 +48,23 @@ public interface MultimapResult<K, V, C> {
     REMOVED_VALUE,
     REMOVED_VALUE_COLLECTION,
     REMOVED_KEY_VALUE,
-    REMOVED_KEY_VALUE_COLLECTION
+    REMOVED_KEY_VALUE_COLLECTION;
+
+    public static int flag(Modification a) {
+      return 1 << a.ordinal();
+    }
+
+    public static int flag(Modification a, Modification b) {
+      return 1 << a.ordinal() | 1 << b.ordinal();
+    }
+
+    public static int flag(Modification a, Modification b, Modification c) {
+      return 1 << a.ordinal() | 1 << b.ordinal() | 1  << c.ordinal();
+    }
+
+    public static boolean isSet(int flags, Modification test) {
+      return (flags & flag(test)) != 0;
+    }
   }
+
 }

--- a/capsule-core/src/main/java/io/usethesource/capsule/core/trie/MultimapResultImpl.java
+++ b/capsule-core/src/main/java/io/usethesource/capsule/core/trie/MultimapResultImpl.java
@@ -7,8 +7,11 @@
  */
 package io.usethesource.capsule.core.trie;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
 
@@ -19,9 +22,7 @@ final class MultimapResultImpl<K, V, C> implements
 
   private Modification modificationEffect = NOTHING;
 
-  // we cache the empty set, since there is only read-only access to this field, and it causes quite some memory allocations
-  private static final Set<Modification> EMPTY_MODIFICATIONS_DETAILS = Collections.unmodifiableSet(EnumSet.noneOf(Modification.class));
-  private Set<Modification> modificationDetails = EMPTY_MODIFICATIONS_DETAILS;
+  private Set<Modification> modificationDetails = Collections.emptySet();
   private Optional<Integer> sizeDelta = Optional.empty();
   private Optional<C> evictedPayload = Optional.empty();
 
@@ -31,8 +32,8 @@ final class MultimapResultImpl<K, V, C> implements
   }
 
   @Override
-  public Set<Modification> getModificationDetails() {
-    return modificationDetails;
+  public boolean containsModification(Modification m) {
+    return modificationDetails.contains(m);
   }
 
   @Override
@@ -47,21 +48,21 @@ final class MultimapResultImpl<K, V, C> implements
 
   @Override
   public void modified(Modification modificationEffect,
-      Set<Modification> modificationDetails) {
+      EnumSet<Modification> modificationDetails) {
     this.modificationEffect = modificationEffect;
     this.modificationDetails = modificationDetails;
   }
 
   @Override
   public void modified(Modification modificationEffect,
-      Set<Modification> modificationDetails, int sizeDelta) {
+      EnumSet<Modification> modificationDetails, int sizeDelta) {
     this.modificationEffect = modificationEffect;
     this.modificationDetails = modificationDetails;
     this.sizeDelta = Optional.of(sizeDelta);
   }
 
   @Override
-  public void modified(Modification modificationEffect, Set<Modification> modificationDetails,
+  public void modified(Modification modificationEffect, EnumSet<Modification> modificationDetails,
       C evictedPayload) {
     this.modificationEffect = modificationEffect;
     this.modificationDetails = modificationDetails;

--- a/capsule-core/src/main/java/io/usethesource/capsule/core/trie/MultimapResultImpl.java
+++ b/capsule-core/src/main/java/io/usethesource/capsule/core/trie/MultimapResultImpl.java
@@ -7,8 +7,10 @@
  */
 package io.usethesource.capsule.core.trie;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Optional;
+import java.util.Set;
 
 import static io.usethesource.capsule.core.trie.MultimapResult.Modification.NOTHING;
 
@@ -16,7 +18,10 @@ final class MultimapResultImpl<K, V, C> implements
     MultimapResult<K, V, C> {
 
   private Modification modificationEffect = NOTHING;
-  private EnumSet<Modification> modificationDetails = EnumSet.noneOf(Modification.class);
+
+  // we cache the empty set, since there is only read-only access to this field, and it causes quite some memory allocations
+  private static final Set<Modification> EMPTY_MODIFICATIONS_DETAILS = Collections.unmodifiableSet(EnumSet.noneOf(Modification.class));
+  private Set<Modification> modificationDetails = EMPTY_MODIFICATIONS_DETAILS;
   private Optional<Integer> sizeDelta = Optional.empty();
   private Optional<C> evictedPayload = Optional.empty();
 
@@ -26,7 +31,7 @@ final class MultimapResultImpl<K, V, C> implements
   }
 
   @Override
-  public EnumSet<Modification> getModificationDetails() {
+  public Set<Modification> getModificationDetails() {
     return modificationDetails;
   }
 
@@ -42,21 +47,21 @@ final class MultimapResultImpl<K, V, C> implements
 
   @Override
   public void modified(Modification modificationEffect,
-      EnumSet<Modification> modificationDetails) {
+      Set<Modification> modificationDetails) {
     this.modificationEffect = modificationEffect;
     this.modificationDetails = modificationDetails;
   }
 
   @Override
   public void modified(Modification modificationEffect,
-      EnumSet<Modification> modificationDetails, int sizeDelta) {
+      Set<Modification> modificationDetails, int sizeDelta) {
     this.modificationEffect = modificationEffect;
     this.modificationDetails = modificationDetails;
     this.sizeDelta = Optional.of(sizeDelta);
   }
 
   @Override
-  public void modified(Modification modificationEffect, EnumSet<Modification> modificationDetails,
+  public void modified(Modification modificationEffect, Set<Modification> modificationDetails,
       C evictedPayload) {
     this.modificationEffect = modificationEffect;
     this.modificationDetails = modificationDetails;

--- a/capsule-core/src/main/java/io/usethesource/capsule/core/trie/MultimapResultImpl.java
+++ b/capsule-core/src/main/java/io/usethesource/capsule/core/trie/MultimapResultImpl.java
@@ -7,15 +7,12 @@
  */
 package io.usethesource.capsule.core.trie;
 
-import java.util.Collection;
+import static io.usethesource.capsule.core.trie.MultimapResult.Modification.NOTHING;
+
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
-
-import static io.usethesource.capsule.core.trie.MultimapResult.Modification.NOTHING;
 
 final class MultimapResultImpl<K, V, C> implements
     MultimapResult<K, V, C> {

--- a/capsule-core/src/main/java/io/usethesource/capsule/core/trie/MultimapResultImpl.java
+++ b/capsule-core/src/main/java/io/usethesource/capsule/core/trie/MultimapResultImpl.java
@@ -19,7 +19,7 @@ final class MultimapResultImpl<K, V, C> implements
 
   private Modification modificationEffect = NOTHING;
 
-  private Set<Modification> modificationDetails = Collections.emptySet();
+  private int modificationDetails = 0;
   private Optional<Integer> sizeDelta = Optional.empty();
   private Optional<C> evictedPayload = Optional.empty();
 
@@ -30,7 +30,7 @@ final class MultimapResultImpl<K, V, C> implements
 
   @Override
   public boolean containsModification(Modification m) {
-    return modificationDetails.contains(m);
+    return Modification.isSet(modificationDetails, m);
   }
 
   @Override
@@ -44,22 +44,22 @@ final class MultimapResultImpl<K, V, C> implements
   }
 
   @Override
-  public void modified(Modification modificationEffect,
-      EnumSet<Modification> modificationDetails) {
+  public void modified(Modification modificationEffect, 
+      int modificationDetails) {
     this.modificationEffect = modificationEffect;
     this.modificationDetails = modificationDetails;
   }
 
   @Override
   public void modified(Modification modificationEffect,
-      EnumSet<Modification> modificationDetails, int sizeDelta) {
+      int modificationDetails, int sizeDelta) {
     this.modificationEffect = modificationEffect;
     this.modificationDetails = modificationDetails;
     this.sizeDelta = Optional.of(sizeDelta);
   }
 
   @Override
-  public void modified(Modification modificationEffect, EnumSet<Modification> modificationDetails,
+  public void modified(Modification modificationEffect, int modificationDetails,
       C evictedPayload) {
     this.modificationEffect = modificationEffect;
     this.modificationDetails = modificationDetails;


### PR DESCRIPTION
After profiling a phase of the rascal bootstrap, I saw that there were 20GB of allocation of the `EnumSet.noneOf()` empty EnumSets. So I change `MultimapResultImpl` to keep around a single instance of the set to avoid the allocations of it. All test still run correctly, so thats a postive sign.

The only global effect is that I've changed the interface to `Set`, such that I can put the shared `EnumSet` unside an `ImmutableSet` wrapper. 


note that the `MultimapResultImpl` is also allocated a lot (10GB), but since it's an mutable object, it's harder to share. Maybe if we made it immutable, it would be easier to avoid all the allocations of `unchanged()`.

btw, is master the right branch to release this from?