### PR TITLE
Fix hash-collision resolution issues in experimental `SetMultimap` and derived types

### DIFF
--- a/src/main/java/io/usethesource/capsule/BinaryRelation.java
+++ b/src/main/java/io/usethesource/capsule/BinaryRelation.java
@@ -7,14 +7,17 @@
  */
 package io.usethesource.capsule;
 
+import io.usethesource.capsule.annotation.Experimental;
 import io.usethesource.capsule.core.PersistentBidirectionalTrieSetMultimap;
 
+@Experimental
 public interface BinaryRelation<T, U> extends SetMultimap<T, U> {
 
   BinaryRelation<U, T> inverse();
 
   SetMultimap<T, U> toSetMultimap();
 
+  @Experimental
   interface Immutable<K, V> extends BinaryRelation<K, V>, SetMultimap.Immutable<K, V> {
 
     @Override
@@ -99,6 +102,7 @@ public interface BinaryRelation<T, U> extends SetMultimap<T, U> {
 
   }
 
+  @Experimental
   interface Transient<K, V> extends BinaryRelation<K, V>, SetMultimap.Transient<K, V> {
 
     @Override

--- a/src/main/java/io/usethesource/capsule/SetMultimap.java
+++ b/src/main/java/io/usethesource/capsule/SetMultimap.java
@@ -111,9 +111,8 @@ public interface SetMultimap<K, V> {
 
     SetMultimap.Immutable<K, V> __put(final K key, final V value);
 
-    default SetMultimap.Immutable<K, V> __put(final K key, final Set.Immutable<V> values) {
-      throw new UnsupportedOperationException("Not yet implemented @ Multi-Map.");
-    }
+    // Map-like semantics: removes all mappings with 'key', for 'key' / 'value' tuples for each of the 'values'
+    SetMultimap.Immutable<K, V> __put(final K key, final Set.Immutable<V> values); // TODO add default implementation?
 
     SetMultimap.Immutable<K, V> __insert(final K key, final V value);
 
@@ -129,10 +128,8 @@ public interface SetMultimap<K, V> {
       return tmp.freeze();
     }
 
-    // removes all mappings with 'key'
-    default SetMultimap.Immutable<K, V> __remove(final K key) {
-      throw new UnsupportedOperationException("Not yet implemented @ Multi-Map.");
-    }
+    // Map-like semantics: removes all mappings with 'key'
+    SetMultimap.Immutable<K, V> __remove(final K key);
 
     SetMultimap.Immutable<K, V> __remove(final K key, final V val);
 

--- a/src/main/java/io/usethesource/capsule/SetMultimap.java
+++ b/src/main/java/io/usethesource/capsule/SetMultimap.java
@@ -16,12 +16,11 @@ import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import io.usethesource.capsule.annotation.Experimental;
 import io.usethesource.capsule.core.PersistentTrieSetMultimap;
 import io.usethesource.capsule.util.EqualityComparator;
 
-/**
- * Experimental interface for a multimap data type.
- */
+@Experimental
 public interface SetMultimap<K, V> {
 
   /**
@@ -107,6 +106,7 @@ public interface SetMultimap<K, V> {
   @Override
   boolean equals(Object other);
 
+  @Experimental
   interface Immutable<K, V> extends SetMultimap<K, V>, SetMultimapEq.Immutable<K, V> {
 
     SetMultimap.Immutable<K, V> __put(final K key, final V value);
@@ -188,6 +188,7 @@ public interface SetMultimap<K, V> {
   /*
    * TODO: consider return types for observability: i.e., either returning Immutable<V> or boolean?
    */
+  @Experimental
   interface Transient<K, V> extends SetMultimap<K, V>, SetMultimapEq.Transient<K, V> {
 
     default boolean __put(final K key, final V value) {

--- a/src/main/java/io/usethesource/capsule/annotation/Experimental.java
+++ b/src/main/java/io/usethesource/capsule/annotation/Experimental.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Michael Steindorfer <Centrum Wiskunde & Informatica> and Contributors.
+ * All rights reserved.
+ * <p>
+ * This file is licensed under the BSD 2-Clause License, which accompanies this project
+ * and is available under https://opensource.org/licenses/BSD-2-Clause.
+ */
+package io.usethesource.capsule.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+
+/**
+ * Indicates an experimental API that change at any time, without any stability or backwards compatibility guarantees.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(value = {ANNOTATION_TYPE, CONSTRUCTOR, FIELD, METHOD, PACKAGE, TYPE})
+@Documented
+public @interface Experimental {
+}

--- a/src/main/java/io/usethesource/capsule/core/PersistentBidirectionalTrieSetMultimap.java
+++ b/src/main/java/io/usethesource/capsule/core/PersistentBidirectionalTrieSetMultimap.java
@@ -167,6 +167,11 @@ public class PersistentBidirectionalTrieSetMultimap<K, V> implements
   }
 
   @Override
+  public SetMultimap.Immutable<K, V> __put(K key, Set.Immutable<V> values) {
+    throw new UnsupportedOperationException("Map semantic unavailable @ Bidirectional Multi-Map.");
+  }
+
+  @Override
   public SetMultimap.Immutable<K, V> __insert(K key, V value) {
     return wireTuple(key, value, fwd::__insert, bwd::__insert);
   }
@@ -177,6 +182,11 @@ public class PersistentBidirectionalTrieSetMultimap<K, V> implements
   @Override
   public SetMultimap.Immutable<K, V> __insert(K key, Set.Immutable<V> values) {
     return batchWireTuple(key, values, fwd::__insert, bwd::__insert);
+  }
+
+  @Override
+  public SetMultimap.Immutable<K, V> __remove(K key) {
+    throw new UnsupportedOperationException("Map semantic unavailable @ Bidirectional Multi-Map.");
   }
 
   @Override

--- a/src/main/java/io/usethesource/capsule/core/PersistentTrieSetMultimap.java
+++ b/src/main/java/io/usethesource/capsule/core/PersistentTrieSetMultimap.java
@@ -2568,7 +2568,7 @@ public class PersistentTrieSetMultimap<K, V> extends
             (kImmutableSetEntry) -> {
               if (kImmutableSetEntry == optionalTuple.get()) {
                 io.usethesource.capsule.Set.Immutable<V> updatedValues =
-                    values.__insertEquivalent(value, cmp);
+                    io.usethesource.capsule.Set.Immutable.of(value);
                 return entryOf(key, updatedValues);
               } else {
                 return kImmutableSetEntry;

--- a/src/main/java/io/usethesource/capsule/core/PersistentTrieSetMultimap.java
+++ b/src/main/java/io/usethesource/capsule/core/PersistentTrieSetMultimap.java
@@ -2558,17 +2558,6 @@ public class PersistentTrieSetMultimap<K, V> extends
           List<Map.Entry<K, io.usethesource.capsule.Set.Immutable<V>>> updatedCollisionContent =
               collisionContent.stream().map(substitutionMapper).collect(Collectors.toList());
 
-          // TODO not all API uses EqualityComparator
-          // TODO does not check that remainder is unmodified
-          assert updatedCollisionContent.size() == collisionContent.size();
-          assert updatedCollisionContent.contains(optionalTuple.get()) == false;
-          // assert updatedCollisionContent.contains(entryOf(key, values.__insertEquivalent(val,
-          // cmp)));
-          assert updatedCollisionContent.stream()
-              .filter(entry -> cmp.equals(key, entry.getKey())
-                  && entry.getValue().containsAllEquivalent(values, cmp))
-              .findAny().isPresent();
-
           final io.usethesource.capsule.Set.Immutable<V> updatedValues =
               updatedCollisionContent.stream().filter(entry -> cmp.equals(key, entry.getKey())).findAny().get().getValue();
           final int sizeDelta = updatedValues.size() - currentValues.size();
@@ -2592,15 +2581,6 @@ public class PersistentTrieSetMultimap<K, V> extends
 
         List<Map.Entry<K, io.usethesource.capsule.Set.Immutable<V>>> updatedCollisionContent =
             builder.build().collect(Collectors.toList());
-
-        // TODO not all API uses EqualityComparator
-        assert updatedCollisionContent.size() == collisionContent.size() + 1;
-        assert updatedCollisionContent.containsAll(collisionContent);
-        // assert updatedCollisionContent.contains(entryOf(key, setOf(val)));
-        assert updatedCollisionContent.stream().filter(entry -> cmp.equals(key, entry.getKey())
-                && Objects.equals(io.usethesource.capsule.Set.Immutable.<V>of().__insertAllEquivalent(values, cmp), entry.getValue()))
-            .findAny()
-            .isPresent();
 
         details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE_COLLECTION), values.size());
         return new HashCollisionNode<K, V>(hash, updatedCollisionContent);

--- a/src/main/java/io/usethesource/capsule/core/PersistentTrieSetMultimap.java
+++ b/src/main/java/io/usethesource/capsule/core/PersistentTrieSetMultimap.java
@@ -596,7 +596,7 @@ public class PersistentTrieSetMultimap<K, V> extends
       assert !(cmp.equals(key0, key1));
 
       if (shift >= HASH_CODE_LENGTH) {
-        return AbstractHashCollisionNode.of(keyHash0, key1, valColl1, key0, valColl1);
+        return AbstractHashCollisionNode.of(keyHash0, key1, valColl1, key0, valColl0);
       }
 
       final int mask0 = mask(keyHash0, shift);

--- a/src/main/java/io/usethesource/capsule/core/PersistentTrieSetMultimap.java
+++ b/src/main/java/io/usethesource/capsule/core/PersistentTrieSetMultimap.java
@@ -2463,6 +2463,11 @@ public class PersistentTrieSetMultimap<K, V> extends
     }
 
     @Override
+    public AbstractSetMultimapNode<K, V> inserted(AtomicReference<Thread> mutator, K key, io.usethesource.capsule.Set.Immutable<V> values, int keyHash, int shift, MultimapResult<K, V, io.usethesource.capsule.Set.Immutable<V>> details, EqualityComparator<Object> cmp) {
+      throw UOE_NOT_YET_IMPLEMENTED_FACTORY.get(); // TODO
+    }
+
+    @Override
     public AbstractSetMultimapNode<K, V> insertedSingle(AtomicReference<Thread> mutator, K key,
         V value,
         int keyHash, int shift,
@@ -2540,6 +2545,11 @@ public class PersistentTrieSetMultimap<K, V> extends
     }
 
     @Override
+    public AbstractSetMultimapNode<K, V> insertedMultiple(AtomicReference<Thread> mutator, K key, io.usethesource.capsule.Set.Immutable<V> values, int keyHash, int shift, MultimapResult<K, V, io.usethesource.capsule.Set.Immutable<V>> details, EqualityComparator<Object> cmp) {
+      throw UOE_NOT_YET_IMPLEMENTED_FACTORY.get(); // TODO
+    }
+
+    @Override
     public AbstractSetMultimapNode<K, V> updatedSingle(AtomicReference<Thread> mutator, K key,
         V value,
         int keyHash,
@@ -2590,6 +2600,11 @@ public class PersistentTrieSetMultimap<K, V> extends
         details.modified(INSERTED_PAYLOAD, MultimapResult.Modification.flag(INSERTED_KEY, INSERTED_VALUE));
         return new HashCollisionNode<K, V>(hash, updatedCollisionContent);
       }
+    }
+
+    @Override
+    public AbstractSetMultimapNode<K, V> updatedMultiple(AtomicReference<Thread> mutator, K key, io.usethesource.capsule.Set.Immutable<V> values, int keyHash, int shift, MultimapResult<K, V, io.usethesource.capsule.Set.Immutable<V>> details, EqualityComparator<Object> cmp) {
+      throw UOE_NOT_YET_IMPLEMENTED_FACTORY.get(); // TODO
     }
 
     @Override

--- a/src/test/java/io/usethesource/capsule/SetMultimapSmokeTest.java
+++ b/src/test/java/io/usethesource/capsule/SetMultimapSmokeTest.java
@@ -8,6 +8,7 @@
 package io.usethesource.capsule;
 
 import java.util.Collection;
+import java.util.Iterator;
 
 import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.generator.Size;
@@ -130,5 +131,122 @@ public class SetMultimapSmokeTest<K, V, CT extends SetMultimap.Immutable<K, V>> 
 
     assertNotEquals(map, mapDifferent);
     assertNotEquals(mapDifferent, map);
+  }
+
+  private int size(Iterator<?> iterator) {
+    int size = 0;
+
+    while (iterator.hasNext()) {
+      size++;
+      iterator.next();
+    }
+
+    return size;
+  }
+
+  @Property
+  public void testHashCollisionPut(
+      @Size(max = 0) final io.usethesource.capsule.core.PersistentTrieSetMultimap<Object, Integer> emptyCollection) { // TODO generic type `SetMultimap.Immutable` not applicable, since `PersistentBidirectionalTrieSetMultimap` doesn't support `__put(K key, Set.Immutable<V> values)`
+
+    Object a = new Object() {
+      public int hashCode() {
+        return 0;
+      }
+    };
+
+    Object b = new Object() {
+      public int hashCode() {
+        return 0;
+      }
+    };
+
+    Object c = new Object() {
+      public int hashCode() {
+        return 0;
+      }
+    };
+
+    final SetMultimap.Immutable<Object, Integer> mapWithBucketsOfSize3 = emptyCollection
+        .__insert(a, 1).__insert(a, 2).__insert(a, 3)
+        .__insert(b, 4).__insert(b, 5).__insert(b, 6)
+        .__insert(c, 7).__insert(c, 8).__insert(c, 9);
+
+    assertEquals(3, mapWithBucketsOfSize3.sizeDistinct());
+    assertEquals(9, mapWithBucketsOfSize3.size());
+    assertEquals(3, size(mapWithBucketsOfSize3.nativeEntryIterator()));
+    assertEquals(9, size(mapWithBucketsOfSize3.entryIterator()));
+
+    final SetMultimap.Immutable<Object, Integer> mapWithBucketsOfSize1 = mapWithBucketsOfSize3
+        .__put(a, 0)
+        .__put(b, 0)
+        .__put(c, 0);
+
+    assertEquals(3, mapWithBucketsOfSize1.sizeDistinct());
+    assertEquals(3, mapWithBucketsOfSize1.size());
+    assertEquals(3, size(mapWithBucketsOfSize1.nativeEntryIterator()));
+    assertEquals(3, size(mapWithBucketsOfSize1.entryIterator()));
+
+    final SetMultimap.Immutable<Object, Integer> mapWithBucketsOfSize2 = mapWithBucketsOfSize3
+        .__put(a, Set.Immutable.of(1, 2))
+        .__put(b, Set.Immutable.of(4, 5))
+        .__put(c, Set.Immutable.of(7, 8));
+
+    assertEquals(3, mapWithBucketsOfSize2.sizeDistinct());
+    assertEquals(6, mapWithBucketsOfSize2.size());
+    assertEquals(3, size(mapWithBucketsOfSize2.nativeEntryIterator()));
+    assertEquals(6, size(mapWithBucketsOfSize2.entryIterator()));
+  }
+
+  @Property
+  public void testHashCollisionInsert(
+      @Size(max = 0) final SetMultimap.Immutable<Object, Integer> emptyCollection) {
+
+    Object a = new Object() {
+      public int hashCode() {
+        return 0;
+      }
+    };
+
+    Object b = new Object() {
+      public int hashCode() {
+        return 0;
+      }
+    };
+
+    Object c = new Object() {
+      public int hashCode() {
+        return 0;
+      }
+    };
+
+    final SetMultimap.Immutable<Object, Integer> mapWithBucketsOfSize1 = emptyCollection
+        .__insert(a, 1)
+        .__insert(b, 4)
+        .__insert(c, 7);
+
+    assertEquals(3, mapWithBucketsOfSize1.sizeDistinct());
+    assertEquals(3, mapWithBucketsOfSize1.size());
+    assertEquals(3, size(mapWithBucketsOfSize1.nativeEntryIterator()));
+    assertEquals(3, size(mapWithBucketsOfSize1.entryIterator()));
+
+    final SetMultimap.Immutable<Object, Integer> mapWithBucketsOfSize2 = mapWithBucketsOfSize1
+        .__insert(a, Set.Immutable.of(2))
+        .__insert(b, Set.Immutable.of(5))
+        .__insert(c, Set.Immutable.of(8));
+
+    assertEquals(3, mapWithBucketsOfSize2.sizeDistinct());
+    assertEquals(6, mapWithBucketsOfSize2.size());
+    assertEquals(3, size(mapWithBucketsOfSize2.nativeEntryIterator()));
+    assertEquals(6, size(mapWithBucketsOfSize2.entryIterator()));
+
+    final SetMultimap.Immutable<Object, Integer> mapWithBucketsOfSize3 = mapWithBucketsOfSize1
+        .__insert(a, Set.Immutable.of(2, 3))
+        .__insert(b, Set.Immutable.of(5, 6))
+        .__insert(c, Set.Immutable.of(8, 9));
+
+    assertEquals(3, mapWithBucketsOfSize3.sizeDistinct());
+    assertEquals(9, mapWithBucketsOfSize3.size());
+    assertEquals(3, size(mapWithBucketsOfSize3.nativeEntryIterator()));
+    assertEquals(9, size(mapWithBucketsOfSize3.entryIterator()));
   }
 }


### PR DESCRIPTION
The PR covers:
* fixes hash-collision bugs in experimental `SetMultimap` and derived types
* adds test cases for aforementioned hash-collision bugs
* adds explicit annotation for experimental API
* implements missing `insertedMultiple` and `updatedMultiple` methods (i.e., derived from existing `insertedSingle` and `updatedSingle` with minor modifications, like returned flags and statistics)

### Follow-up Action Items
* Release `v0.7.1` with bug fixes included in this PR
* Consider releasing final `v0.6.4` with bug fixes included in this PR (Java 8 target level)