### PR TITLE
Implement basic `toString` for transient sets and maps

### DIFF
--- a/src/main/java/io/usethesource/capsule/core/PersistentTrieMap.java
+++ b/src/main/java/io/usethesource/capsule/core/PersistentTrieMap.java
@@ -482,9 +482,10 @@ public class PersistentTrieMap<K, V> implements io.usethesource.capsule.Map.Immu
 
   @Override
   public String toString() {
-    String body =
-        entrySet().stream().map(entry -> String.format("%s: %s", entry.getKey(), entry.getValue()))
-            .reduce((o1, o2) -> String.join(", ", o1, o2)).orElse("");
+    String body = entrySet().stream()
+        .map(entry -> String.format("%s: %s", entry.getKey(), entry.getValue()))
+        .reduce((left, right) -> String.join(", ", left, right))
+        .orElse("");
     return String.format("{%s}", body);
   }
 
@@ -2420,6 +2421,15 @@ public class PersistentTrieMap<K, V> implements io.usethesource.capsule.Map.Immu
     @Override
     public int hashCode() {
       return cachedHashCode;
+    }
+
+    @Override
+    public String toString() {
+      String body = entrySet().stream()
+          .map(entry -> String.format("%s: %s", entry.getKey(), entry.getValue()))
+          .reduce((left, right) -> String.join(", ", left, right))
+          .orElse("");
+      return String.format("{%s}", body);
     }
 
     @Override

--- a/src/main/java/io/usethesource/capsule/core/PersistentTrieSet.java
+++ b/src/main/java/io/usethesource/capsule/core/PersistentTrieSet.java
@@ -395,7 +395,9 @@ public class PersistentTrieSet<K> implements Set.Immutable<K>, java.io.Serializa
 
   @Override
   public String toString() {
-    String body = stream().map(k -> k.toString()).reduce((o1, o2) -> String.join(", ", o1, o2))
+    String body = stream()
+        .map(element -> element.toString())
+        .reduce((left, right) -> String.join(", ", left, right))
         .orElse("");
     return String.format("{%s}", body);
   }
@@ -2128,6 +2130,15 @@ public class PersistentTrieSet<K> implements Set.Immutable<K>, java.io.Serializa
     @Override
     public int hashCode() {
       return cachedHashCode;
+    }
+
+    @Override
+    public String toString() {
+      String body = stream()
+          .map(element -> element.toString())
+          .reduce((left, right) -> String.join(", ", left, right))
+          .orElse("");
+      return String.format("{%s}", body);
     }
 
   }


### PR DESCRIPTION
Also rename variable in `toString` for persistent sets and maps and reformat those lines.

