### PR TITLE
added more tests with hashCode=0 collisions

### DIFF
--- a/src/test/java/io/usethesource/capsule/MapSmokeTest.java
+++ b/src/test/java/io/usethesource/capsule/MapSmokeTest.java
@@ -191,6 +191,15 @@ public class MapSmokeTest {
 
     Map.Immutable map = mapOf();
 
+    int collisionHash = 0;
+    Map.Immutable res0 = map.__put(p(11, collisionHash), p(11, collisionHash)).__put(p(12, collisionHash), p(12, collisionHash));
+    assertTrue(res0.containsKey(p(11, collisionHash)));
+    assertTrue(res0.containsKey(p(12, collisionHash)));
+    res0 = res0.__remove(p(12, collisionHash));
+    assertTrue(res0.containsKey(p(11, collisionHash)));
+    assertFalse(res0.containsKey(p(12, collisionHash)));
+    assertEquals(mapOf(p(11, collisionHash), p(11, collisionHash)), res0);
+
     Map.Immutable res1 = map.__put(p(11, 1), p(11, 1)).__put(p(12, 1), p(12, 1));
     assertTrue(res1.containsKey(p(11, 1)));
     assertTrue(res1.containsKey(p(12, 1)));
@@ -213,27 +222,33 @@ public class MapSmokeTest {
 
   @Test
   public void testCheckCompactionFromBeginUponDelete_HashCollisionNode2() {
+      testCheckCompactionFromBeginUponDelete_HashCollisionNode2(0);
+      testCheckCompactionFromBeginUponDelete_HashCollisionNode2(1);
+      testCheckCompactionFromBeginUponDelete_HashCollisionNode2(32769);
+  }
+
+  private void testCheckCompactionFromBeginUponDelete_HashCollisionNode2(int hash) {
 
     Map.Immutable map = mapOf();
 
     Map.Immutable res1 =
-        map.__put(p(32769_1, 32769), p(32769_1, 32769)).__put(p(32769_2, 32769), p(32769_2, 32769));
+        map.__put(p(32769_1, 32769), p(32769_1, hash)).__put(p(32769_2, hash), p(32769_2, hash));
     assertEquals(2, res1.size());
-    assertTrue(res1.containsKey(p(32769_1, 32769)));
-    assertTrue(res1.containsKey(p(32769_2, 32769)));
+    assertTrue(res1.containsKey(p(32769_1, hash)));
+    assertTrue(res1.containsKey(p(32769_2, hash)));
 
     Map.Immutable res2 = res1.__put(p(1, 1), p(1, 1));
     assertEquals(3, res2.size());
     assertTrue(res2.containsKey(p(1, 1)));
-    assertTrue(res2.containsKey(p(32769_1, 32769)));
-    assertTrue(res2.containsKey(p(32769_2, 32769)));
+    assertTrue(res2.containsKey(p(32769_1, hash)));
+    assertTrue(res2.containsKey(p(32769_2, hash)));
 
-    Map.Immutable res3 = res2.__remove(p(32769_2, 32769));
+    Map.Immutable res3 = res2.__remove(p(32769_2, hash));
     assertEquals(2, res3.size());
     assertTrue(res3.containsKey(p(1, 1)));
-    assertTrue(res3.containsKey(p(32769_1, 32769)));
+    assertTrue(res3.containsKey(p(32769_1, hash)));
 
-    Map.Immutable expected = mapOf(p(1, 1), p(1, 1), p(32769_1, 32769), p(32769_1, 32769));
+    Map.Immutable expected = mapOf(p(1, 1), p(1, 1), p(32769_1, hash), p(32769_1, hash));
     assertEquals(expected, res3);
   }
 

--- a/src/test/java/io/usethesource/capsule/SetSmokeTest.java
+++ b/src/test/java/io/usethesource/capsule/SetSmokeTest.java
@@ -169,7 +169,7 @@ public class SetSmokeTest {
         .of(hash_n2147483648_obj1, hash_p1073741824_obj2);
 
     for (CollidableInteger x : xs) {
-      todo.remove(x);
+      todo.remove(x); 
     }
 
     assertEquals(Collections.EMPTY_SET, todo);
@@ -189,6 +189,19 @@ public class SetSmokeTest {
   }
 
   @Test
+  public void TwoCollisionsZeroEquals() {
+    CollidableInteger hash0_obj1 = new CollidableInteger(1, 0);
+    CollidableInteger hash0_obj2 = new CollidableInteger(2, 0);
+
+    io.usethesource.capsule.Set.Immutable<CollidableInteger> xs = PersistentTrieSet
+        .of(hash0_obj1, hash0_obj2);
+    io.usethesource.capsule.Set.Immutable<CollidableInteger> ys = PersistentTrieSet
+        .of(hash0_obj2, hash0_obj1);
+
+    assertEquals(xs, ys);
+  }
+
+  @Test
   public void ThreeCollisionsEquals() {
     CollidableInteger hash98304_obj1 = new CollidableInteger(1, 98304);
     CollidableInteger hash98304_obj2 = new CollidableInteger(2, 98304);
@@ -203,6 +216,20 @@ public class SetSmokeTest {
   }
 
   @Test
+  public void ThreeCollisionsZeroEquals() {
+    CollidableInteger hash0_obj1 = new CollidableInteger(1, 0);
+    CollidableInteger hash0_obj2 = new CollidableInteger(2, 0);
+    CollidableInteger hash0_obj3 = new CollidableInteger(3, 0);
+
+    io.usethesource.capsule.Set.Immutable<CollidableInteger> xs = PersistentTrieSet
+        .of(hash0_obj1, hash0_obj2, hash0_obj3);
+    io.usethesource.capsule.Set.Immutable<CollidableInteger> ys = PersistentTrieSet
+        .of(hash0_obj3, hash0_obj2, hash0_obj1);
+
+    assertEquals(xs, ys);
+  }
+
+  @Test
   public void RemovalFromCollisonNodeEqualsSingelton() {
     CollidableInteger hash98304_obj1 = new CollidableInteger(1, 98304);
     CollidableInteger hash98304_obj2 = new CollidableInteger(2, 98304);
@@ -210,6 +237,18 @@ public class SetSmokeTest {
     io.usethesource.capsule.Set.Immutable<CollidableInteger> xs = PersistentTrieSet.of(hash98304_obj1);
     io.usethesource.capsule.Set.Immutable<CollidableInteger> ys =
         PersistentTrieSet.of(hash98304_obj1, hash98304_obj2).__remove(hash98304_obj2);
+
+    assertEquals(xs, ys);
+  }
+
+  @Test
+  public void RemovalFromCollisonNodeEqualsSingeltonZero() {
+    CollidableInteger hash0_obj1 = new CollidableInteger(1, 0);
+    CollidableInteger hash0_obj2 = new CollidableInteger(2, 0);
+
+    io.usethesource.capsule.Set.Immutable<CollidableInteger> xs = PersistentTrieSet.of(hash0_obj1);
+    io.usethesource.capsule.Set.Immutable<CollidableInteger> ys =
+        PersistentTrieSet.of(hash0_obj1, hash0_obj2).__remove(hash0_obj2);
 
     assertEquals(xs, ys);
   }
@@ -244,6 +283,20 @@ public class SetSmokeTest {
         .of(hash98304_obj1, hash98304_obj2, hash268435456_obj3).__remove(hash268435456_obj3);
     io.usethesource.capsule.Set.Immutable<CollidableInteger> ys = PersistentTrieSet
         .of(hash98304_obj1, hash98304_obj2);
+
+    assertEquals(xs, ys);
+  }
+
+  @Test
+  public void CollisionWithMergeInlineAbove1Zero() {
+    CollidableInteger hash0_obj1 = new CollidableInteger(1, 0);
+    CollidableInteger hash0_obj2 = new CollidableInteger(2, 0);
+    CollidableInteger hash0_obj3 = new CollidableInteger(3, 0);
+
+    io.usethesource.capsule.Set.Immutable<CollidableInteger> xs = PersistentTrieSet
+        .of(hash0_obj1, hash0_obj2, hash0_obj3).__remove(hash0_obj3);
+    io.usethesource.capsule.Set.Immutable<CollidableInteger> ys = PersistentTrieSet
+        .of(hash0_obj1, hash0_obj2);
 
     assertEquals(xs, ys);
   }


### PR DESCRIPTION
I'm debugging some issues with relation and map key removal on the vallang level and rascal level. They all relate to hashCode=0 collisions so I added some tests here to rule out a bug in capsule.