### PR TITLE
Honor set-multimap hash-collision node invariant during removals

### DIFF
--- a/src/main/java/io/usethesource/capsule/core/PersistentTrieSetMultimap.java
+++ b/src/main/java/io/usethesource/capsule/core/PersistentTrieSetMultimap.java
@@ -2223,6 +2223,8 @@ public class PersistentTrieSetMultimap<K, V> extends
         final List<Map.Entry<K, io.usethesource.capsule.Set.Immutable<V>>> collisionContent) {
       this.hash = hash;
       this.collisionContent = collisionContent;
+
+      assert this.collisionContent.size() >= 2;
     }
 
     @Override


### PR DESCRIPTION
### Context

Hash-collision nodes were able to underflow upon removals and store a single remaining (non-colliding) key. This violated the canonical representation assumption and led to erroneously skipping compaction. This PR adds invariant checking and ensures that invariants are honored during removals.

### Triaging 

With the information provided in #41, I was able to pinpoint the issue after attaching a debugger to the Rascal REPL and execute the provided equality comparison. It turned out that an invariant assertion was missing in the set-multi map ([that was now inserted](https://github.com/usethesource/capsule/commit/c4c32d956ba000a6b489706f8191a006001b6fd5)), although it was present in the set and map data types.

Once the invariant check was added, the property-based test suite flagged the invariant violation. Hence the coverage of generated inputs is sufficiently covers scenarios that elicit the behaviour reported in #41:

```
% ./gradlew test --tests "SetMultimap*"

> Task :test

SetMultimapPropertiesTestSuite$PersistentBidirectionalTrieSetMultimapTest > notContainedAfterInsertRemove FAILED
    java.lang.AssertionError at PropertyFalsified.java:52
        Caused by: java.lang.AssertionError at PersistentTrieSetMultimap.java:2227

SetMultimapPropertiesTestSuite$PersistentBidirectionalTrieSetMultimapTest > sizeAfterTransientInsertKeyValues FAILED
    java.lang.AssertionError at PersistentTrieSetMultimap.java:2227
        Caused by: java.lang.AssertionError at PersistentTrieSetMultimap.java:2227

SetMultimapPropertiesTestSuite$PersistentTrieSetMultimapTest > notContainedAfterInsertRemove FAILED
    java.lang.AssertionError at PropertyFalsified.java:52
        Caused by: java.lang.AssertionError at PersistentTrieSetMultimap.java:2227

SetMultimapPropertiesTestSuite$PersistentTrieSetMultimapTest > sizeAfterTransientInsertKeyValues FAILED
    java.lang.AssertionError at PersistentTrieSetMultimap.java:2227
        Caused by: java.lang.AssertionError at PersistentTrieSetMultimap.java:2227

37 tests completed, 4 failed

> Task :test FAILED
```

### Validating

With [the fix](https://github.com/usethesource/capsule/commit/abcf9f8140320ef1f6eacecdae72e4430d609bc7) present in this PR, the property-based test suite does not show any invariant violations for set-multimap hash-collision nodes any more.

```
% ./gradlew test --tests "SetMultimap*"                                            

BUILD SUCCESSFUL in 1m 1s
```